### PR TITLE
typos, grammatic, formatting/unicode errors & inconsistent wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
   The Ballistic JIT Engine
 </h1>
 
-<p align="center"><em>“The world's fastest ARM recompiler"</em></p>
+<p align="center"><em>„The world's fastest ARM recompiler“</em></p>
 
 # Overview
 
-This is a rewrite the dynarmic recompiler, with the goal of fixing its many flaws.
+This is a rewrite of the dynarmic recompiler, with the goal of fixing its many flaws.
 
 # Building Ballistic
 
-## Install Dependancies
+## Install Dependencies
 
 ### macOS
 

--- a/docs/header_template.h
+++ b/docs/header_template.h
@@ -1,23 +1,23 @@
 /** @file module.h
- *
- * @brief A description of the module’s purpose.  
- *   
- * @par          
- */     
+ * 
+ * @brief A description of the module's purpose.
+ * 
+ * @par
+ */
 
 #ifndef MODULE_H
-#define MODULE_H  
+#define MODULE_H
 
-/*!   
- * @brief Identify the larger of two 8-bit integers.   
- *
- * @param[in] num1  The first number to be compared.   
- * @param[in] num2  The second number to be compared.   
- *
+/*!
+ * @brief Identify the larger of two 8-bit integers.
+ * 
+ * @param[in] num1  The first number to be compared.
+ * @param[in] num2  The second number to be compared.
+ * 
  * @return The value of the larger number.
  */
-int8_t max8(int8_t num1, int8_t num2);   
+int8_t max8(int8_t num1, int8_t num2);
 
-#endif /* MODULE_H */   
+#endif /* MODULE_H */
 
 /*** end of file ***/

--- a/docs/source_template.c
+++ b/docs/source_template.c
@@ -1,27 +1,27 @@
-/** @file module.c   
+/** @file module.c
  * 
- * @brief A description of the module’s purpose.    
+ * @brief A description of the module's purpose.
  * 
- * @par          
- */    
+ * @par
+ */
 
 #include <stdint.h> 
 #include <stdbool.h> 
 
-#include “module.h”    
+#include "module.h"
 
-/*!   
- * @brief Identify the larger of two 8-bit integers.   
+/*!
+ * @brief Identify the larger of two 8-bit integers.
  * 
- * @param[in] num1  The first number to be compared.   
- * @param[in] num2  The second number to be compared.   
+ * @param[in] num1  The first number to be compared.
+ * @param[in] num2  The second number to be compared.
  * 
- * @return The value of the larger number. 
- */  
+ * @return The value of the larger number.
+ */
 int8_t
 max8 (int8_t num1, int8_t num2)
-{      
-    return ((num1 > num2) ? num1 : num2); 
-}   
+{
+    return ((num1 > num2) ? num1 : num2);
+}
 
 /*** end of file ***/

--- a/tests/test_decoder.c
+++ b/tests/test_decoder.c
@@ -84,8 +84,8 @@ tests_test_decoder(void)
                 {
                     ref_result = local_candidates[k].metadata;
 
-                    // Collision Check. Does the next candidate also matches
-                    // and has the same priority?
+                    // Collision Check. Does the next candidate also match
+                    // and is of the same priority?
                     //
                     if (BAL_UNLIKELY(k + 1 < candidate_count))
                     {
@@ -103,7 +103,7 @@ tests_test_decoder(void)
                         }
                     }
 
-                    // Found hight priority match.
+                    // Found high priority match.
                     //
                     break;
                 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,10 +1,10 @@
 # Tools
 
-This folder holds scritps needed to build Ballistic and standalone programs used for testing Ballistic.
+This folder holds scripts needed to build Ballistic and standalone programs used for testing Ballistic.
 
-## Standlone Programs
+## Standalone Programs
 
-These programs will appear in directory you compile Ballistic with.
+These programs will appear in the directory you compile Ballistic in.
 
 ### Ballistic CLI
 
@@ -12,7 +12,7 @@ This is used by developers to test Ballistic's translation loop.
 
 ### CDoc
 
-This creates rustdoc like documentation for C code. CDoc completely relies on
+This creates rustdoc-like documentation for C code. CDoc completely relies on
 Clang and LLVM so only Unix systems are supported. Builing CDoc on Windows is
 not supported at this time.
 
@@ -33,7 +33,7 @@ Done! Open ../docs/cdoc/index.html
 
 **Disclaimer**: I have absolutely zero motivation to create a documentation
 generator so `cdoc.c` is made completely with AI. The code is messy but the
-generated HTML files look beautiful. 
+generated HTML files look beautiful.
 
 ### Coverage CLI
 
@@ -49,12 +49,12 @@ Mnemonic: ADD - Mask: 0x7F200000 - Expected: 0x0B000000
 
 ## Scripts
 
-These scripts are solely used for building Ballistic and is called by CMake.
+These scripts are solely used for building Ballistic and are called by CMake.
 
 ### Generate A64 Table
 
-This script parses the Official ARM Machine Readable Architecture Specification XML files in `spec/` and generates a hash table Ballistic's decoder uses to lookup instructions.
+This script parses the Official ARM Machine Readable Architecture Specification XML files in `spec/` and generates a hash table that's used by Ballistic's decoder to lookup instructions.
 
 ### Doctest
 
-This script extract, compile, and validate code examples written in documentation. This replicates Rust doctest feature, where users can embed code in documentation using markdown. This script is can be run in the `build/` directory using `ctest --verbose -R DocTest`.
+This script extracts, compiles, and validates code examples written in the documentation. This replicates Rust's doctest feature, where users can embed code in documentation using markdown. This script can be run in the `build/` directory using `ctest --verbose -R DocTest`.

--- a/tools/cdoc.c
+++ b/tools/cdoc.c
@@ -176,7 +176,6 @@ item_exists(FileContext *ctx, const char *name)
 }
 
 // --- 3. LINK RESOLUTION ---
-// --- 3. LINK RESOLUTION ---
 
 // NEW: Helper to find any symbol (Item, Enum Variant, or Struct.Field)
 // Returns 1 if found, setting out_file and out_anchor. 0 otherwise.

--- a/tools/coverage_cli.c
+++ b/tools/coverage_cli.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define INSTRUCTION_TRACKER_SIZE 2048 // Not sure what exact value to pur here.
+#define INSTRUCTION_TRACKER_SIZE 2048 // Not sure what exact value to put here.
 
 typedef struct
 {


### PR DESCRIPTION
## Description
Fixes various textual errors in `./, tools/, docs/`
Please skim over [IR_DESIGN_DOC.md](https://github.com/pound-emu/ballistic/compare/main...smiRaphi:ballistic:main#diff-81f4fb8ce0d335d1d42e1e405d64ec23be209541e035f0edf09b6c6b05054728) for any unwanted changes of meaning on my part.
I also changed the quotes in the main README from a mix of ASCII and Unicode to the Unicode lower & upper ones because I like how it fits with italic but that's just subjective.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional change, code cleanup)
- [ ] Performance improvement
