### PR TITLE
Fix GCC Errors

### DIFF
--- a/include/bal_logging.h
+++ b/include/bal_logging.h
@@ -57,6 +57,8 @@
 
 #include "bal_attributes.h"
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
 
 /// Defines the severity of a log message.
 typedef enum
@@ -155,7 +157,7 @@ BAL_COLD void bal_logger_init_default(bal_logger_t *logger);
 #define BAL_LOG(logger, log_level, format, ...)                         \
     do                                                                  \
     {                                                                   \
-        if (!(logger))                                                  \
+        if (((uintptr_t)logger) == (uintptr_t)NULL)                     \
         {                                                               \
             break;                                                      \
         }                                                               \

--- a/src/bal_decoder.c
+++ b/src/bal_decoder.c
@@ -7,7 +7,7 @@ const bal_decoder_instruction_metadata_t *
 bal_decode_arm64(const uint32_t instruction)
 {
     // Index is top 11 bits
-    const uint16_t index = instruction >> 21;
+    const uint16_t index = (uint16_t)(instruction >> 21);
 
     const decoder_bucket_t *bucket = &g_decoder_lookup_table[index];
     for (size_t i = 0; i < bucket->count; ++i)

--- a/src/bal_engine.c
+++ b/src/bal_engine.c
@@ -32,8 +32,7 @@ static uint32_t    extract_operand_value(const uint32_t, const bal_decoder_opera
 static uint32_t    intern_constant(bal_translation_context_t *, const bal_constant_t);
 static inline void translate_const(bal_translation_context_t *,
                                    const bal_decoder_instruction_metadata_t *,
-                                   uint32_t *,
-                                   const bal_decoder_operand_t *);
+                                   uint32_t *);
 BAL_COLD bal_error_t
 bal_engine_init(bal_allocator_t *allocator, bal_engine_t *engine, bal_logger_t logger)
 {
@@ -193,7 +192,7 @@ bal_engine_translate(bal_engine_t *BAL_RESTRICT           engine,
         switch (metadata->ir_opcode)
         {
             case OPCODE_CONST:
-                translate_const(&context, metadata, arm_registers, operands_cursor);
+                translate_const(&context, metadata, arm_registers);
                 break;
             default:
                 BAL_LOG_DEBUG(context.logger,
@@ -324,17 +323,16 @@ get_or_create_ssa_index(bal_translation_context_t *context, uint64_t register_in
 }
 
 BAL_HOT static inline void
-translate_const(bal_translation_context_t *BAL_RESTRICT                context,
-                const bal_decoder_instruction_metadata_t *BAL_RESTRICT metadata,
-                uint32_t *BAL_RESTRICT                                 arm_registers,
-                const bal_decoder_operand_t *BAL_RESTRICT              operands)
+translate_const(bal_translation_context_t                *context,
+                const bal_decoder_instruction_metadata_t *metadata,
+                uint32_t                                 *arm_registers)
 {
     uint64_t rd    = arm_registers[0];
     uint64_t imm16 = arm_registers[1];
     uint64_t hw    = arm_registers[2];
     uint64_t shift = hw * 16;
 
-    uint64_t mask = (32 == operands[0].bit_width) ? 0xFFFFFFFFULL : 0xFFFFFFFFFFFFFFFFULL;
+    uint64_t mask = 0xFFFFFFFFFFFFFFFFULL;
 
     // Calculate the shifted immediate value.
     //

--- a/tools/cdoc.c
+++ b/tools/cdoc.c
@@ -386,7 +386,7 @@ resolve_links(ProjectContext *proj, const char *text, const char *current_file)
             const char *end   = strstr(start, "`]");
             if (end)
             {
-                int  name_len = end - start;
+                int  name_len = (int)(end - start);
                 char name[128];
                 if (name_len < 127)
                 {


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

1. Fixes GCC warnings that do not deserve me writing an indepth explanation on what needed to be changed.

2. The original mask calculation for OPCODE_MOV makes zero sense because the bit width for operands[0] is always > 31. I don't know what I was thinking when I wrote this. The mask is now set to cover 32 and 64-bit immediate values.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change, code cleanup)
- [ ] Performance improvement

## Code Review Process
**IMPORTANT**: This project maintains an extremely high standard for code quality and correctness. By submitting this pull request, you acknowledge and agree to the following:

1. **You must be able to defend every single line of code you have added or modified**
2. **You must be prepared to explain the reasoning behind every design decision**
3. **You must be able to discuss and justify your approach to solving the problem**
4. **You must be ready to address all feedback and make requested changes**
5. **You must have thoroughly tested your changes and be confident in their correctness**

The code review process for this project is intentionally tedious and thorough. Do not submit a pull request unless you are prepared to defend your PR changes.

## Breaking Changes
If this change introduces any breaking changes, please describe them here.

## Checklist
- [X] My code follows the project's coding style guidelines
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have read the project's CONTRIBUTING guidelines
- [X] I understand and agree to the rigorous code review process described above
