### PR TITLE
fix NULL parameter guards and format-string bug

### DIFF
--- a/include/bal_engine.h
+++ b/include/bal_engine.h
@@ -140,7 +140,7 @@ BAL_COLD bal_error_t bal_engine_init(const bal_allocator_t *allocator,
 ///
 /// # Safety
 ///
-/// If `guest_address_staart` is `NULL`, we assume the entry point is 0x0.
+/// `guest_address_start` must be non-NULL.
 ///
 /// # Errors
 ///

--- a/src/bal_assembler.c
+++ b/src/bal_assembler.c
@@ -16,6 +16,7 @@ bal_assembler_init(bal_assembler_t *assembler, void *buffer, const size_t size, 
     if (NULL == buffer)
     {
         BAL_LOG_ERROR(&logger, "Buffer is NULL.");
+        return BAL_ERROR_INVALID_ARGUMENT;
     }
 
     if ((uintptr_t)buffer % 4 != 0)

--- a/src/bal_assembler.c
+++ b/src/bal_assembler.c
@@ -21,7 +21,7 @@ bal_assembler_init(bal_assembler_t *assembler, void *buffer, const size_t size, 
 
     if ((uintptr_t)buffer % 4 != 0)
     {
-        BAL_LOG_ERROR(&logger, "Buffer %p is not 4-byte aligned.");
+        BAL_LOG_ERROR(&logger, "Buffer %p is not 4-byte aligned.", buffer);
         return BAL_ERROR_MEMORY_ALIGNMENT;
     }
 

--- a/src/bal_engine.c
+++ b/src/bal_engine.c
@@ -146,9 +146,11 @@ bal_engine_translate(bal_engine_t *BAL_RESTRICT                 engine,
         return engine->status;
     }
 
-    if (BAL_UNLIKELY(NULL == &guest_address_start))
+    if (BAL_UNLIKELY(NULL == guest_address_start))
     {
-        BAL_LOG_INFO(&engine->logger, "Guest Address is NULL, assuming entry point is 0x0");
+        BAL_LOG_ERROR(&engine->logger, "Guest Address is NULL, aborting translation");
+        engine->status = BAL_ERROR_INVALID_ARGUMENT;
+        return engine->status;
     }
 
     const size_t max_instructions_size_bytes = max_instructions * ARM_INSTRUCTION_SIZE_BYTES;


### PR DESCRIPTION
## Description

Three independent bug fixes, each delivered as an atomic commit across `bal_engine.c` and `bal_assembler.c`.

1. **`engine: reject NULL guest_address_start properly`** — the NULL guard at the top of `bal_engine_translate` was written as `NULL == &guest_address_start`, which tests the address of the parameter slot and is therefore always false. A caller that passed NULL (as the header's `# Safety` section promised was allowed) would immediately crash on the subsequent `*guest_address_start` dereference. The translation loop dereferences and advances the value through this pointer to track guest-block progress, so a NULL input has no sensible fallback. Replaced the dead check with a real NULL guard returning `BAL_ERROR_INVALID_ARGUMENT`, matching the other parameter guards in this function, and updated the header's `# Safety` section to document the requirement.

2. **`assembler: reject NULL buffer in init`** — `bal_assembler_init` logged an error when `buffer` was NULL but fell through to the alignment check and the assignment below, so the function stored NULL into `assembler->buffer` and returned `BAL_SUCCESS` to the caller. The header already documents `BAL_ERROR_INVALID_ARGUMENT` as the expected return; this commit returns it explicitly.

3. **`assembler: pass buffer pointer to alignment error log`** — the alignment error used `%p` with no matching argument, so the log would either skip the pointer field or pull an adjacent stack slot depending on the ABI. Passed `buffer` as the intended argument.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change, code cleanup)
- [ ] Performance improvement

## Code Review Process
**IMPORTANT**: This project maintains an extremely high standard for code quality and correctness. By submitting this pull request, you acknowledge and agree to the following:

1. **You must be able to defend every single line of code you have added or modified**
2. **You must be prepared to explain the reasoning behind every design decision**
3. **You must be able to discuss and justify your approach to solving the problem**
4. **You must be ready to address all feedback and make requested changes**
5. **You must have thoroughly tested your changes and be confident in their correctness**

The code review process for this project is intentionally tedious and thorough. Do not submit a pull request unless you are prepared to defend your PR changes.

## Breaking Changes
None. The new NULL guard in `bal_engine_translate` tightens behaviour only for inputs that would previously crash. No caller in the tree passes NULL.

## Checklist
- [x] My code follows the project's coding style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read the project's CONTRIBUTING guidelines
- [x] I understand and agree to the rigorous code review process described above