### PR TITLE
assembler: fix branch encoding and add reset function

### DIFF
--- a/include/bal_assembler.h
+++ b/include/bal_assembler.h
@@ -71,6 +71,13 @@ extern "C"
                                    size_t           size,
                                    bal_logger_t     logger);
 
+    /// Resets the assembler back to its initial state.
+    ///
+    /// # Safety
+    ///
+    /// `assembler` must be valid.
+    void bal_assembler_reset(bal_assembler_t *assembler);
+
     /// Emit a `ADD` (Immediate) instruction.
     ///
     /// Adds a register value `rn` and 12 bit immediate value `imm12` with the optional left shift

--- a/src/bal_assembler.c
+++ b/src/bal_assembler.c
@@ -1,5 +1,6 @@
 #include "bal_assembler.h"
 #include <stdbool.h>
+#include <string.h>
 
 static bool can_emit(bal_assembler_t *assembler);
 static void emit_mov(bal_assembler_t *, const char *, uint32_t, uint16_t, uint8_t, uint32_t);
@@ -37,6 +38,19 @@ bal_assembler_init(bal_assembler_t   *assembler,
     BAL_LOG_INFO(
         &logger, "Assembler initialized. Buffer: %p, Capacity: %zu instructions.", buffer, size);
     return BAL_SUCCESS;
+}
+
+void
+bal_assembler_reset(bal_assembler_t *assembler)
+{
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    assembler->offset = 0;
+    assembler->status = BAL_SUCCESS;
+    (void)memset(assembler->buffer, 0, assembler->capacity * sizeof(uint32_t));
 }
 
 void
@@ -242,16 +256,7 @@ bal_emit_b(bal_assembler_t *assembler, const int32_t offset)
 
     // WARNING: Cast to uint32_t safely applies bitwise masking to negative values.
     const uint32_t imm26       = (uint32_t)(offset / 4) & 0x03FFFFFF;
-    uint32_t       instruction = 0;
-
-    if (0 == imm26)
-    {
-        instruction = hard_coded_bits;
-    }
-    else
-    {
-        instruction = hard_coded_bits / imm26;
-    }
+    const uint32_t instruction = hard_coded_bits | imm26;
 
     const char *mnemonic = "B";
     BAL_LOG_TRACE(&assembler->logger,


### PR DESCRIPTION
## Description
The B (unconditional branch) instruction encoding used integer division (/) instead of bitwise OR (|) to combine the opcode with the branch offset. This produced incorrect machine code for every branch target other than zero.

Also add bal_assembler_reset() to match the reset API provided by every other module in Ballistic (bal_x86_assembler, sliding window, tier1 compiler). The function zeroes the instruction buffer and resets offset and status.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the project's coding style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have read the project's CONTRIBUTING guidelines
- [ ] I understand and agree to the rigorous code review process described above
