### PR TITLE
assembler: handle ORR-aliased MOV instructions in Tier 1 compiler

### DIFF
--- a/include/backend/x86/bal_x86_assembler.h
+++ b/include/backend/x86/bal_x86_assembler.h
@@ -372,6 +372,66 @@ extern "C"
                                            bal_x86_register_t   source,
                                            int32_t              offset);
 
+    /// Emits a 64-bit left shift by an immediate amount.
+    ///
+    /// Assembly equivalent: `shl reg64, imm8`
+    ///
+    /// # Warning
+    ///
+    /// This function fails if:
+    ///
+    /// - `assembler` is `NULL`.
+    /// - `assembler->status` != [`BAL_SUCCESS`]
+    /// - `assembler->buffer` is full.
+    void bal_x86_emit_shl_r64_imm8(bal_x86_assembler_t *assembler,
+                                   bal_x86_register_t   reg,
+                                   uint8_t              imm8);
+
+    /// Emits a 64-bit right shift by an immediate amount.
+    ///
+    /// Assembly equivalent: `shr reg64, imm8`
+    ///
+    /// # Warning
+    ///
+    /// This function fails if:
+    ///
+    /// - `assembler` is `NULL`.
+    /// - `assembler->status` != [`BAL_SUCCESS`]
+    /// - `assembler->buffer` is full.
+    void bal_x86_emit_shr_r64_imm8(bal_x86_assembler_t *assembler,
+                                   bal_x86_register_t   reg,
+                                   uint8_t              imm8);
+
+    /// Emits a 64-bit arithmetic right shift by an immediate amount.
+    ///
+    /// Assembly equivalent: `sar reg64, imm8`
+    ///
+    /// # Warning
+    ///
+    /// This function fails if:
+    ///
+    /// - `assembler` is `NULL`.
+    /// - `assembler->status` != [`BAL_SUCCESS`]
+    /// - `assembler->buffer` is full.
+    void bal_x86_emit_sar_r64_imm8(bal_x86_assembler_t *assembler,
+                                   bal_x86_register_t   reg,
+                                   uint8_t              imm8);
+
+    /// Emits a 64-bit rotate right by an immediate amount.
+    ///
+    /// Assembly equivalent: `ror reg64, imm8`
+    ///
+    /// # Warning
+    ///
+    /// This function fails if:
+    ///
+    /// - `assembler` is `NULL`.
+    /// - `assembler->status` != [`BAL_SUCCESS`]
+    /// - `assembler->buffer` is full.
+    void bal_x86_emit_ror_r64_imm8(bal_x86_assembler_t *assembler,
+                                   bal_x86_register_t   reg,
+                                   uint8_t              imm8);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/backend/x86/bal_x86_assembler.c
+++ b/src/backend/x86/bal_x86_assembler.c
@@ -459,6 +459,231 @@ bal_x86_emit_store_r64_rbp_offset(bal_x86_assembler_t     *assembler,
 }
 
 void
+bal_x86_emit_shl_r64_imm8(bal_x86_assembler_t     *assembler,
+                          const bal_x86_register_t reg,
+                          const uint8_t            imm8)
+{
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    if (BAL_UNLIKELY(assembler->status != BAL_SUCCESS))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Aborting function: assembler status != BAL_SUCCESS");
+        return;
+    }
+
+    const bool is_valid_register_result = is_valid_register(reg);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Invalid register: %d", reg);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    const size_t instruction_size_bytes = 4;
+    const bool   can_emit_status        = can_emit(assembler, instruction_size_bytes);
+
+    if (BAL_UNLIKELY(false == can_emit_status))
+    {
+        return;
+    }
+
+    BAL_LOG_DEBUG(&assembler->logger, "[+0x%04zx] shl r%d, %u", assembler->offset, reg, imm8);
+
+    // WARNING: reg is verified by is_valid_register() to fall within
+    // the safe enum range [0, 15].
+    const uint8_t b          = (uint8_t)reg >> 3;
+    const size_t  old_offset = assembler->offset;
+
+    // WARNING: Cast literal 4U to bal_x86_register_t for the ModRM reg
+    // field. This is the x86 SHL opcode extension (/4), not a register index.
+    emit_rex(assembler->buffer, &assembler->offset, 1U, 0U, b);
+    emit8(assembler->buffer, &assembler->offset, 0xC1U);
+    emit_modrm_register(assembler->buffer, &assembler->offset, (bal_x86_register_t)4U, reg);
+    emit8(assembler->buffer, &assembler->offset, imm8);
+
+    // WARNING: Cast bytes_emitted and instruction_size_bytes to int for %d
+    // format in BAL_ASSERT_MSG, matching the existing codebase pattern.
+    // Both values are guaranteed to fit in int (max 4 bytes).
+    const size_t bytes_emitted = assembler->offset - old_offset;
+    BAL_ASSERT_MSG(bytes_emitted == instruction_size_bytes,
+                   "Bytes emitted %d does not match instruction size %d",
+                   (int)bytes_emitted,
+                   (int)instruction_size_bytes);
+}
+
+void
+bal_x86_emit_shr_r64_imm8(bal_x86_assembler_t     *assembler,
+                          const bal_x86_register_t reg,
+                          const uint8_t            imm8)
+{
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    if (BAL_UNLIKELY(assembler->status != BAL_SUCCESS))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Aborting function: assembler status != BAL_SUCCESS");
+        return;
+    }
+
+    const bool is_valid_register_result = is_valid_register(reg);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Invalid register: %d", reg);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    const size_t instruction_size_bytes = 4;
+    const bool   can_emit_status        = can_emit(assembler, instruction_size_bytes);
+
+    if (BAL_UNLIKELY(false == can_emit_status))
+    {
+        return;
+    }
+
+    BAL_LOG_DEBUG(&assembler->logger, "[+0x%04zx] shr r%d, %u", assembler->offset, reg, imm8);
+
+    // WARNING: reg is verified by is_valid_register() to fall within
+    // the safe enum range [0, 15].
+    const uint8_t b          = (uint8_t)reg >> 3;
+    const size_t  old_offset = assembler->offset;
+
+    // WARNING: Cast literal 5U to bal_x86_register_t for the ModRM reg
+    // field. This is the x86 SHR opcode extension (/5), not a register index.
+    emit_rex(assembler->buffer, &assembler->offset, 1U, 0U, b);
+    emit8(assembler->buffer, &assembler->offset, 0xC1U);
+    emit_modrm_register(assembler->buffer, &assembler->offset, (bal_x86_register_t)5U, reg);
+    emit8(assembler->buffer, &assembler->offset, imm8);
+
+    // WARNING: Casts to int for %d format in BAL_ASSERT_MSG are safe because
+    // both values are at most 4 (instruction size in bytes).
+    const size_t bytes_emitted = assembler->offset - old_offset;
+    BAL_ASSERT_MSG(bytes_emitted == instruction_size_bytes,
+                   "Bytes emitted %d does not match instruction size %d",
+                   (int)bytes_emitted,
+                   (int)instruction_size_bytes);
+}
+
+void
+bal_x86_emit_sar_r64_imm8(bal_x86_assembler_t     *assembler,
+                          const bal_x86_register_t reg,
+                          const uint8_t            imm8)
+{
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    if (BAL_UNLIKELY(assembler->status != BAL_SUCCESS))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Aborting function: assembler status != BAL_SUCCESS");
+        return;
+    }
+
+    const bool is_valid_register_result = is_valid_register(reg);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Invalid register: %d", reg);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    const size_t instruction_size_bytes = 4;
+    const bool   can_emit_status        = can_emit(assembler, instruction_size_bytes);
+
+    if (BAL_UNLIKELY(false == can_emit_status))
+    {
+        return;
+    }
+
+    BAL_LOG_DEBUG(&assembler->logger, "[+0x%04zx] sar r%d, %u", assembler->offset, reg, imm8);
+
+    // WARNING: reg is verified by is_valid_register() to fall within
+    // the safe enum range [0, 15].
+    const uint8_t b          = (uint8_t)reg >> 3;
+    const size_t  old_offset = assembler->offset;
+
+    // WARNING: Cast literal 7U to bal_x86_register_t for the ModRM reg
+    // field. This is the x86 SAR opcode extension (/7), not a register index.
+    emit_rex(assembler->buffer, &assembler->offset, 1U, 0U, b);
+    emit8(assembler->buffer, &assembler->offset, 0xC1U);
+    emit_modrm_register(assembler->buffer, &assembler->offset, (bal_x86_register_t)7U, reg);
+    emit8(assembler->buffer, &assembler->offset, imm8);
+
+    // WARNING: Casts to int for %d format in BAL_ASSERT_MSG are safe because
+    // both values are at most 4 (instruction size in bytes).
+    const size_t bytes_emitted = assembler->offset - old_offset;
+    BAL_ASSERT_MSG(bytes_emitted == instruction_size_bytes,
+                   "Bytes emitted %d does not match instruction size %d",
+                   (int)bytes_emitted,
+                   (int)instruction_size_bytes);
+}
+
+void
+bal_x86_emit_ror_r64_imm8(bal_x86_assembler_t     *assembler,
+                          const bal_x86_register_t reg,
+                          const uint8_t            imm8)
+{
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    if (BAL_UNLIKELY(assembler->status != BAL_SUCCESS))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Aborting function: assembler status != BAL_SUCCESS");
+        return;
+    }
+
+    const bool is_valid_register_result = is_valid_register(reg);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger, "Invalid register: %d", reg);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    const size_t instruction_size_bytes = 4;
+    const bool   can_emit_status        = can_emit(assembler, instruction_size_bytes);
+
+    if (BAL_UNLIKELY(false == can_emit_status))
+    {
+        return;
+    }
+
+    BAL_LOG_DEBUG(&assembler->logger, "[+0x%04zx] ror r%d, %u", assembler->offset, reg, imm8);
+
+    // WARNING: reg is verified by is_valid_register() to fall within
+    // the safe enum range [0, 15].
+    const uint8_t b          = (uint8_t)reg >> 3;
+    const size_t  old_offset = assembler->offset;
+
+    // WARNING: Cast literal 1U to bal_x86_register_t for the ModRM reg
+    // field. This is the x86 ROR opcode extension (/1), not a register index.
+    emit_rex(assembler->buffer, &assembler->offset, 1U, 0U, b);
+    emit8(assembler->buffer, &assembler->offset, 0xC1U);
+    emit_modrm_register(assembler->buffer, &assembler->offset, (bal_x86_register_t)1U, reg);
+    emit8(assembler->buffer, &assembler->offset, imm8);
+
+    // WARNING: Casts to int for %d format in BAL_ASSERT_MSG are safe because
+    // both values are at most 4 (instruction size in bytes).
+    const size_t bytes_emitted = assembler->offset - old_offset;
+    BAL_ASSERT_MSG(bytes_emitted == instruction_size_bytes,
+                   "Bytes emitted %d does not match instruction size %d",
+                   (int)bytes_emitted,
+                   (int)instruction_size_bytes);
+}
+
+void
 bal_x86_emit_mov_r64_r64(bal_x86_assembler_t     *assembler,
                          const bal_x86_register_t destination,
                          const bal_x86_register_t source)

--- a/src/backend/x86/bal_x86_tier1_compiler.c
+++ b/src/backend/x86/bal_x86_tier1_compiler.c
@@ -44,8 +44,29 @@ static void     translate_jump(bal_tier1_compiler_t                     *compile
                                bal_guest_address_t                      *target_pc);
 static void     translate_mov(bal_tier1_compiler_t                     *compiler,
                               const bal_decoder_instruction_metadata_t *metadata,
-                              uint32_t                                  instruction);
+                              const uint32_t                            instruction);
+static void     translate_mov_orr(bal_tier1_compiler_t                     *compiler,
+                                  const bal_decoder_instruction_metadata_t *metadata,
+                                  const uint32_t                            instruction);
+static void     handle_orr_immediate(bal_tier1_compiler_t                     *compiler,
+                                     const bal_decoder_instruction_metadata_t *metadata,
+                                     const uint32_t                            instruction);
+static void     handle_orr_shifted_register(bal_tier1_compiler_t                     *compiler,
+                                             const bal_decoder_instruction_metadata_t *metadata,
+                                             const uint32_t                            instruction);
+BAL_HOT static void emit_orr_shifted_raw(bal_tier1_compiler_t             *compiler,
+                                      const bal_x86_register_t         x86_rd,
+                                      const bal_x86_register_t         x86_rn,
+                                      const bal_x86_register_t         x86_rm,
+                                      const uint32_t                   imm6,
+                                      const uint32_t                   shift_type,
+                                      const int32_t                    datasize,
+                                      const bool                       has_x86_rn);
 
+static uint64_t decode_bitmask_immediate(const uint32_t N,
+                                         const uint32_t immr,
+                                         const uint32_t imms,
+                                         const int32_t  datasize);
 bal_error_t
 bal_tier1_compiler_init(bal_tier1_compiler_t         *compiler,
                         const bal_executable_buffer_t executable_buffer,
@@ -268,8 +289,10 @@ bal_tier1_compiler_translate(bal_tier1_compiler_t         *compiler,
 
             switch (metadata->ir_opcode)
             {
+                case OPCODE_MOV:
+                    translate_mov_orr(compiler, metadata, instruction);
+                    break;
                 case OPCODE_CONST:;
-                    // TODO: implement support for the rest MOV instructions.
                     const char variant = metadata->name[3];
 
                     if (BAL_LIKELY(variant == 'N') || BAL_LIKELY(variant == 'K')
@@ -566,16 +589,18 @@ translate_jump(bal_tier1_compiler_t *BAL_RESTRICT                     compiler,
     (void)compiler;
 }
 
-void
+BAL_HOT static void
 translate_mov(bal_tier1_compiler_t                     *compiler,
               const bal_decoder_instruction_metadata_t *metadata,
               const uint32_t                            instruction)
 {
+    // WARNING: Cast to uint8_t is safe because ARM64 register indices
+    // are in the range [0, 31].
     const uint8_t  rd      = (uint8_t)extract_operand_value(instruction, &metadata->operands[0]);
     const uint64_t imm16   = extract_operand_value(instruction, &metadata->operands[1]);
     const uint64_t hw      = extract_operand_value(instruction, &metadata->operands[2]);
     const uint64_t shift   = hw * 16ULL;
-    const uint64_t mask    = metadata->operands[0].type == BAL_OPERAND_TYPE_REGISTER_32
+    const uint64_t mask    = BAL_OPERAND_TYPE_REGISTER_32 == metadata->operands[0].type
                                  ? 0xFFFFFFFFULL
                                  : 0xFFFFFFFFFFFFFFFFULL;
     const char     variant = metadata->name[3];
@@ -633,3 +658,426 @@ translate_mov(bal_tier1_compiler_t                     *compiler,
     }
     compiler->is_dirty[rd] = true;
 }
+
+BAL_HOT static uint64_t
+decode_bitmask_immediate(const uint32_t N,
+                         const uint32_t immr,
+                         const uint32_t imms,
+                         const int32_t  datasize)
+{
+    // WARNING: N, immr, imms are extracted from the raw ARM64 instruction's
+    // bitmask immediate fields. datasize must be 32 or 64.
+
+    // Compute the highest set bit in N:imms to find the element size.
+    // For 64-bit: 7 bit value (N + imms[5:0]).
+    // For 32-bit: 5 bit value (imms[4:0]), N is ignored.
+    //
+    uint32_t test = (N << 6U) | imms;
+
+    if (32 == datasize)
+    {
+        // WARNING: For 32-bit, only the lower 5 bits of imms are used.
+        test &= 0x1FU;
+    }
+
+    // WARNING: All-ones in the relevant bits means all-ones result.
+    if (((64 == datasize) && (0x7FU == test)) || ((32 == datasize) && (0x1FU == test)))
+    {
+        return (64 == datasize) ? ~0ULL : 0xFFFFFFFFULL;
+    }
+
+    // Find the highest set bit in 'test' to determine the element size.
+    //
+    const uint32_t max_bit = (64 == datasize) ? 6U : 4U;
+    int32_t       len      = 0;
+
+    for (uint32_t i = max_bit; i != UINT32_MAX; --i)
+    {
+        if (test & (1U << i))
+        {
+            // WARNING: Cast uint32_t i (max 6) to int32_t is safe.
+            len = (int32_t)i;
+            break;
+        }
+    }
+
+    // WARNING: esize must be at least 2. Enforce len >= 1.
+    if (0 == len)
+    {
+        len = 1;
+    }
+
+    const int32_t  esize  = 1 << len;
+
+    // WARNING: Cast len (0-6) to uint64_t for safe shift.
+    const uint64_t levels = (1ULL << (uint64_t)len) - 1ULL;
+
+    // WARNING: Narrowing cast from uint64_t to int32_t is safe because
+    // levels is at most 63, and AND with levels guarantees the result fits.
+    const int32_t S = (int32_t)((uint64_t)imms & levels);
+    const int32_t R = (int32_t)((uint64_t)immr & levels);
+
+    // Create (S + 1) consecutive 1 bits, rotate right by R.
+    //
+    uint64_t mask = 0ULL;
+
+    // WARNING: (S + 1) can be up to 64. 1ULL << 64 is undefined behavior.
+    if ((uint64_t)(S + 1) >= 64ULL)
+    {
+        mask = ~0ULL;
+    }
+    else
+    {
+        // WARNING: Cast to uint64_t prevents undefined shift behavior.
+        mask = (1ULL << (uint64_t)(S + 1)) - 1ULL;
+    }
+
+    if (0U != (uint32_t)R)
+    {
+        // WARNING: Casts to uint64_t ensure safe 64-bit rotation.
+        mask = (mask >> (uint64_t)R) | (mask << (uint64_t)(esize - R));
+    }
+
+    // WARNING: Mask to esize bits when esize is smaller than 64.
+    if (esize < 64)
+    {
+        // WARNING: Cast esize to uint64_t for safe shift.
+        mask &= (1ULL << (uint64_t)esize) - 1ULL;
+    }
+
+    // Replicate the pattern to fill the full datasize.
+    //
+    int32_t current_esize = esize;
+
+    while (current_esize < datasize)
+    {
+        mask = (mask << current_esize) | mask;
+        current_esize *= 2;
+    }
+
+    // WARNING: For 32-bit operations, clear the upper 32 bits.
+    if (32 == datasize)
+    {
+        mask &= 0xFFFFFFFFULL;
+    }
+
+    return mask;
+}
+
+BAL_HOT static void
+translate_mov_orr(bal_tier1_compiler_t                     *compiler,
+                  const bal_decoder_instruction_metadata_t *metadata,
+                  const uint32_t                            instruction)
+{
+    // WARNING: The decoder maps 11 ORR encodings to OPCODE_MOV.
+    // 7 are NEON/SIMD (rejected here), 4 are scalar (handled below).
+
+    const bal_logger_t *BAL_RESTRICT logger = &compiler->logger;
+
+    // Step 1: SIMD detection. Reject REGISTER_128 or non-standard width.
+    //
+    for (uint32_t i = 0; i < BAL_OPERANDS_SIZE; ++i)
+    {
+        const uint16_t type = metadata->operands[i].type;
+        const uint16_t bw   = metadata->operands[i].bit_width;
+
+        if (BAL_UNLIKELY(BAL_OPERAND_TYPE_REGISTER_128 == type))
+        {
+            BAL_LOG_ERROR(logger,
+                          "Unsupported SIMD ORR variant: %s", metadata->name);
+            compiler->status = BAL_ERROR_UNKNOWN_INSTRUCTION;
+            return;
+        }
+
+        if (BAL_UNLIKELY((BAL_OPERAND_TYPE_NONE != type)
+                         && (BAL_OPERAND_TYPE_IMMEDIATE != type)
+            && (BAL_OPERAND_TYPE_CONDITION != type)
+            // WARNING: 5 is the bit width of ARM register indices (32 regs).
+            && (5 != bw)))
+        {
+            BAL_LOG_ERROR(logger,
+                          "Unsupported SIMD ORR variant: %s", metadata->name);
+            compiler->status = BAL_ERROR_UNKNOWN_INSTRUCTION;
+            return;
+        }
+    }
+
+    // Step 2: Count defined operands.
+    //
+    uint32_t operand_count = 0;
+
+    for (uint32_t i = 0; i < BAL_OPERANDS_SIZE; ++i)
+    {
+        if (BAL_OPERAND_TYPE_NONE != metadata->operands[i].type)
+        {
+            ++operand_count;
+        }
+    }
+
+    // Step 3: Dispatch based on operand count.
+    //
+    if (2 == operand_count)
+    {
+        handle_orr_immediate(compiler, metadata, instruction);
+        return;
+    }
+
+    if (5 == operand_count)
+    {
+        handle_orr_shifted_register(compiler, metadata, instruction);
+        return;
+    }
+
+    // Step 4: Fallback for unexpected operand counts.
+    //
+    BAL_LOG_ERROR(logger,
+                  "Unsupported OPCODE_MOV variant"
+                  " with %u operands: %s",
+                  operand_count,
+                  metadata->name);
+    compiler->status = BAL_ERROR_UNKNOWN_INSTRUCTION;
+}
+
+BAL_HOT static void
+handle_orr_immediate(bal_tier1_compiler_t                     *compiler,
+                     const bal_decoder_instruction_metadata_t *metadata,
+                     const uint32_t                            instruction)
+{
+    const uint32_t rd
+        = extract_operand_value(instruction, &metadata->operands[0]);
+    const uint32_t rn
+        = extract_operand_value(instruction, &metadata->operands[1]);
+
+    // WARNING: N:immr:imms are not exposed by the decoder. Extract
+    // them directly from the raw instruction word.
+    const uint32_t N    = (instruction >> 22U) & 1U;
+    const uint32_t immr = (instruction >> 16U) & 0x3FU;
+    const uint32_t imms = (instruction >> 10U) & 0x3FU;
+    const int32_t  datasize
+        = (BAL_OPERAND_TYPE_REGISTER_64
+           == metadata->operands[0].type) ? 64 : 32;
+
+    const uint64_t mask
+        = decode_bitmask_immediate(N, immr, imms, datasize);
+
+    if (31 == rn)
+    {
+        // MOV Wd/Xd, #imm alias (Rn = XZR).
+        // WARNING: Cast rd to uint8_t is safe (range [0, 31]).
+        const bool               skip_load = true;
+        const bal_x86_register_t x86_rd
+            = allocate_x86_register(compiler, (uint8_t)rd, skip_load);
+        const bal_x86_macro_t mov_macro = {
+            .opcode              = BAL_X86_MACRO_MOV_REGISTER_IMMEDIATE,
+            .destination         = x86_rd,
+            .immediate_or_offset = mask,
+        };
+        bal_sliding_window_push(&compiler->window, mov_macro);
+    }
+    else
+    {
+        // General ORR Wd/Xd, Wn/Xn, #imm.
+        // WARNING: Casts to uint8_t are safe (range [0, 31]).
+        const bal_x86_register_t x86_rn
+            = allocate_x86_register(compiler, (uint8_t)rn, false);
+        const bal_x86_register_t x86_rd
+            = allocate_x86_register(compiler, (uint8_t)rd, true);
+
+        if (x86_rd != x86_rn)
+        {
+            const bal_x86_macro_t mov_macro = {
+                .opcode      = BAL_X86_MACRO_MOV_REGISTER_REGISTER,
+                .destination = x86_rd,
+                .source      = x86_rn,
+            };
+            bal_sliding_window_push(&compiler->window, mov_macro);
+        }
+
+        const bal_x86_macro_t or_macro = {
+            .opcode              = BAL_X86_MACRO_OR_REGISTER_IMMEDIATE,
+            .destination         = x86_rd,
+            .immediate_or_offset = mask,
+        };
+        bal_sliding_window_push(&compiler->window, or_macro);
+
+        // WARNING: For 32-bit operations, zero-extend the result to
+        // clear the upper 32 bits of the x86 register.
+        if (32 == datasize)
+        {
+            const bal_x86_macro_t and_macro = {
+                .opcode = BAL_X86_MACRO_AND_REGISTER_IMMEDIATE,
+                .destination = x86_rd,
+                .immediate_or_offset = 0xFFFFFFFFULL,
+            };
+            bal_sliding_window_push(&compiler->window, and_macro);
+        }
+    }
+
+    compiler->is_dirty[rd] = true;
+}
+
+BAL_HOT static void
+handle_orr_shifted_register(bal_tier1_compiler_t                     *compiler,
+                             const bal_decoder_instruction_metadata_t *metadata,
+                             const uint32_t                            instruction)
+{
+    // WARNING: Casts to uint8_t are safe (range [0, 31]).
+    const uint32_t rd
+        = extract_operand_value(instruction, &metadata->operands[0]);
+    const uint32_t rn
+        = extract_operand_value(instruction, &metadata->operands[1]);
+    const uint32_t imm6
+        = extract_operand_value(instruction, &metadata->operands[2]);
+    const uint32_t rm
+        = extract_operand_value(instruction, &metadata->operands[3]);
+    const uint32_t shift_type
+        = extract_operand_value(instruction, &metadata->operands[4]);
+
+    // MOV Xd/Wd, Xm (register copy: ORR Xd, XZR, Xm).
+    //
+    if ((31 == rn) && (0 == imm6) && (0 == shift_type))
+    {
+        // WARNING: Casts to uint8_t are safe (range [0, 31]).
+        const bal_x86_register_t x86_rm
+            = allocate_x86_register(compiler, (uint8_t)rm, false);
+        const bal_x86_register_t x86_rd
+            = allocate_x86_register(compiler, (uint8_t)rd, true);
+
+        // WARNING: Skip identity move when x86_rd == x86_rm.
+        if (x86_rd != x86_rm)
+        {
+            const bal_x86_macro_t mov_macro = {
+                .opcode      = BAL_X86_MACRO_MOV_REGISTER_REGISTER,
+                .destination = x86_rd,
+                .source      = x86_rm,
+            };
+            bal_sliding_window_push(&compiler->window, mov_macro);
+        }
+
+        // WARNING: For 32-bit operations, zero-extend the result.
+        const int32_t regcopy_datasize
+            = (BAL_OPERAND_TYPE_REGISTER_64
+               == metadata->operands[0].type) ? 64 : 32;
+
+        if (32 == regcopy_datasize)
+        {
+            const bal_x86_macro_t and_macro = {
+                .opcode = BAL_X86_MACRO_AND_REGISTER_IMMEDIATE,
+                .destination = x86_rd,
+                .immediate_or_offset = 0xFFFFFFFFULL,
+            };
+            bal_sliding_window_push(&compiler->window, and_macro);
+        }
+
+        compiler->is_dirty[rd] = true;
+        return;
+    }
+
+    // General ORR Xd, Xn, Xm {shift_type #imm6}.
+    //
+    if (BAL_UNLIKELY(shift_type > 2))
+    {
+        BAL_LOG_ERROR(&compiler->logger,
+                      "Unsupported ORR shift type: %u", shift_type);
+        compiler->status = BAL_ERROR_UNKNOWN_INSTRUCTION;
+        return;
+    }
+
+    const int32_t datasize
+        = (BAL_OPERAND_TYPE_REGISTER_64
+           == metadata->operands[0].type) ? 64 : 32;
+
+    // WARNING: Allocate sources before dest to avoid register aliasing.
+    // WARNING: When rn == 31 (XZR), do NOT load from x[31].
+    //
+    // WARNING: Casts to uint8_t are safe (range [0, 31]).
+    const bal_x86_register_t x86_rm
+        = allocate_x86_register(compiler, (uint8_t)rm, false);
+    bal_x86_register_t x86_rn    = BAL_X86_INVALID;
+    bool               has_x86_rn = false;
+
+    if (31 != rn)
+    {
+        x86_rn    = allocate_x86_register(compiler, (uint8_t)rn, false);
+        has_x86_rn = true;
+    }
+
+    const bal_x86_register_t x86_rd
+        = allocate_x86_register(compiler, (uint8_t)rd, true);
+
+    emit_orr_shifted_raw(compiler, x86_rd, x86_rn, x86_rm,
+                         imm6, shift_type, datasize, has_x86_rn);
+
+    compiler->is_dirty[rd] = true;
+}
+
+BAL_HOT static void
+emit_orr_shifted_raw(bal_tier1_compiler_t             *compiler,
+                     const bal_x86_register_t          x86_rd,
+                     const bal_x86_register_t          x86_rn,
+                     const bal_x86_register_t          x86_rm,
+                     const uint32_t                    imm6,
+                     const uint32_t                    shift_type,
+                     const int32_t                     datasize,
+                     const bool                        has_x86_rn)
+{
+    // Flush window so R11 is free for raw assembler emission.
+    //
+    bal_sliding_window_flush_all(&compiler->window);
+
+    // Copy Rm to R11 and shift it.
+    //
+    bal_x86_emit_mov_r64_r64(&compiler->assembler, BAL_X86_R11, x86_rm);
+
+    // WARNING: imm6 is at most 63, safe to cast to uint8_t.
+    switch (shift_type)
+    {
+        case 0:
+            bal_x86_emit_shl_r64_imm8(
+                &compiler->assembler, BAL_X86_R11, (uint8_t)imm6);
+            break;
+        case 1:
+            bal_x86_emit_shr_r64_imm8(
+                &compiler->assembler, BAL_X86_R11, (uint8_t)imm6);
+            break;
+        case 2:
+            bal_x86_emit_sar_r64_imm8(
+                &compiler->assembler, BAL_X86_R11, (uint8_t)imm6);
+            break;
+        default:
+            break;
+    }
+
+    if (false == has_x86_rn)
+    {
+        // WARNING: No Rn (XZR case). Xd = Rm << shift.
+        bal_x86_emit_mov_r64_r64(
+            &compiler->assembler, x86_rd, BAL_X86_R11);
+    }
+    else
+    {
+        // WARNING: Skip identity move when x86_rd == x86_rn.
+        if (x86_rd != x86_rn)
+        {
+            bal_x86_emit_mov_r64_r64(
+                &compiler->assembler, x86_rd, x86_rn);
+        }
+
+        bal_x86_emit_or_r64_r64(
+            &compiler->assembler, x86_rd, BAL_X86_R11);
+    }
+
+    // WARNING: For 32-bit operations, zero-extend the result.
+    if (32 == datasize)
+    {
+        const bal_x86_macro_t and_macro = {
+            .opcode              = BAL_X86_MACRO_AND_REGISTER_IMMEDIATE,
+            .destination         = x86_rd,
+            .immediate_or_offset = 0xFFFFFFFFULL,
+        };
+        bal_sliding_window_push(&compiler->window, and_macro);
+        bal_sliding_window_flush_all(&compiler->window);
+    }
+}
+
+/*** end of file ***/

--- a/src/bal_engine.c
+++ b/src/bal_engine.c
@@ -731,6 +731,9 @@ bal_engine_translate_tier2(bal_engine_t *BAL_RESTRICT                 engine,
                 case OPCODE_CONST:
                     translate_const(&context, metadata, arm_instruction_operands);
                     break;
+                case OPCODE_MOV:
+                    translate_mov_ir(&context, metadata, arm_instruction_operands);
+                    break;
                 case OPCODE_SUB:
                     translate_sub(&context, metadata, arm_instruction_operands);
                     break;
@@ -907,6 +910,23 @@ get_or_create_ssa_index(bal_translation_context_t *context, const uint64_t regis
     context->ir_instruction_cursor++;
     context->bit_width_cursor++;
     return ssa_index;
+}
+
+static void
+translate_mov_ir(bal_translation_context_t                *context,
+                  const bal_decoder_instruction_metadata_t *metadata,
+                  const uint32_t                           *arm_registers)
+{
+    // WARNING: This function is behind #if 0 and is not currently compiled.
+    // Full IR emission for OPCODE_MOV will be implemented when the Tier 2
+    // compiler frontend is enabled.
+    //
+    BAL_LOG_DEBUG(context->logger,
+                  "  SKIPPED: OPCODE_MOV not yet implemented in IR layer: %s",
+                  metadata->name);
+    (void)context;
+    (void)metadata;
+    (void)arm_registers;
 }
 
 BAL_HOT static void
@@ -1134,3 +1154,5 @@ translate_sub(bal_translation_context_t                *context,
     context->instruction_count++;
 }
 #endif
+
+/*** end of file ***/


### PR DESCRIPTION
## Description
The decoder maps every ORR instruction to OPCODE_MOV, but the Tier 1 compiler never handled that opcode. Any ORR instruction would hit the default case and terminate the block with an error.

This adds a case for OPCODE_MOV that handles all 4 scalar variants:
- MOV Xd, Xm (register copy, detected when Rn == XZR and shift == 0)
- MOV Xd, #imm (immediate alias, same but with bitmask encoding)
- ORR Xd, Xn, Xm {shift} (general shifted register ORR)
- ORR Xd, Xn, #imm (general bitmask immediate ORR)

The remaining 7 entries are NEON/SIMD variants which get rejected at translation time since the Tier 1 compiler has no vector support.

I also had to add 4 shift-by-imm8 emitter functions to the x86 backend (SHL, SHR, SAR, ROR) using the 0xC1 opcode, plus a static helper for decoding the ARM64 bitmask immediate format (N:immr:imms).


## Type of Change
- [x] New feature (non-breaking change which adds functionality)
