### PR TITLE
assembler: add bal_x86_emit_sub_r64_r64 + tests

### DIFF
--- a/include/backend/x86/bal_x86_assembler.h
+++ b/include/backend/x86/bal_x86_assembler.h
@@ -187,6 +187,21 @@ extern "C"
                                   bal_x86_register_t   destination,
                                   bal_x86_register_t   source);
 
+    /// Emits a subtract 64-bit register from another 64-bit register.
+    ///
+    /// Assembly equivalent: `sub destination, source`
+    ///
+    /// # Warning
+    ///
+    /// This function fails if:
+    ///
+    /// - `assembler` is `NULL`
+    /// - `assembler->status` != [`BAL_SUCCESS`]
+    /// - `assembler->buffer` is full.
+    void bal_x86_emit_sub_r64_r64(bal_x86_assembler_t *assembler,
+                                  bal_x86_register_t   destination,
+                                  bal_x86_register_t   source);
+
     /// Emits a bitwise AND instruction between two 64-bit registers.
     ///
     /// Assembly equivalent: `and destination, source`.

--- a/src/backend/x86/bal_x86_assembler.c
+++ b/src/backend/x86/bal_x86_assembler.c
@@ -990,6 +990,82 @@ bal_x86_emit_add_r64_r64(bal_x86_assembler_t     *assembler,
 }
 
 void
+bal_x86_emit_sub_r64_r64(bal_x86_assembler_t     *assembler,
+                         const bal_x86_register_t destination,
+                         const bal_x86_register_t source)
+{
+
+    if (BAL_UNLIKELY(NULL == assembler))
+    {
+        return;
+    }
+
+    if (BAL_UNLIKELY(assembler->status != BAL_SUCCESS))
+    {
+        BAL_LOG_ERROR(&assembler->logger,
+                      "Aborting function: assembler->status != BAL_SUCCESS");
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    bool is_valid_register_result = is_valid_register(source);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger,
+                      "Aborting function: invalid source register: %d",
+                      source);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    is_valid_register_result = is_valid_register(destination);
+
+    if (BAL_UNLIKELY(false == is_valid_register_result))
+    {
+        BAL_LOG_ERROR(&assembler->logger,
+                      "Aborting function: invalid destination register: %d",
+                      destination);
+        assembler->status = BAL_ERROR_INVALID_ARGUMENT;
+        return;
+    }
+
+    const size_t instruction_size_bytes = 3;
+    const bool   can_emit_status
+        = can_emit(assembler, instruction_size_bytes);
+
+    if (BAL_UNLIKELY(false == can_emit_status))
+    {
+        return;
+    }
+
+    BAL_LOG_DEBUG(&assembler->logger,
+                  "[+0x%04zx] sub r%d, r%d",
+                  assembler->offset,
+                  destination,
+                  source);
+    const uint8_t w = 1;
+
+    // WARNING: Destination is verified by is_valid_register().
+    const uint8_t r = (uint8_t)destination >> 3;
+
+    // WARNING: Source is verified by is_valid_register().
+    const uint8_t b = (uint8_t)source >> 3;
+
+    const uint8_t opcode     = 0x2B;
+    const size_t  old_offset = assembler->offset;
+    emit_rex(assembler->buffer, &assembler->offset, w, r, b);
+    emit8(assembler->buffer, &assembler->offset, opcode);
+    emit_modrm_register(
+        assembler->buffer, &assembler->offset, destination, source);
+    const size_t bytes_emitted = assembler->offset - old_offset;
+    BAL_ASSERT_MSG(bytes_emitted == instruction_size_bytes,
+                   "Bytes emitted %d does not match instruction size %d",
+                   bytes_emitted,
+                   instruction_size_bytes);
+}
+
+void
 bal_x86_emit_add_r64_imm32(bal_x86_assembler_t     *assembler,
                            const bal_x86_register_t destination,
                            const int32_t            immediate)

--- a/tests/backend/x86/test_x86_assembler.cpp
+++ b/tests/backend/x86/test_x86_assembler.cpp
@@ -123,6 +123,7 @@ TEST_F(Backendx86Assembler, Public_NullContext_NoCrash)
     bal_x86_emit_add_mem64_rbp_offset_imm(nullptr, 0, 0);
     bal_x86_emit_add_r64_imm32(nullptr, BAL_X86_RAX, 0);
     bal_x86_emit_add_r64_r64(nullptr, BAL_X86_RAX, BAL_X86_RBX);
+    bal_x86_emit_sub_r64_r64(nullptr, BAL_X86_RAX, BAL_X86_RBX);
     bal_x86_emit_and_r64_r64(nullptr, BAL_X86_RAX, BAL_X86_RAX);
     bal_x86_emit_jcc_rel32(nullptr, BAL_X86_COND_A, 0);
     bal_x86_emit_jmp_r64(nullptr, BAL_X86_RAX);
@@ -144,6 +145,10 @@ TEST_F(Backendx86Assembler, Public_BadStatus_NoEmit)
     assembler.status = BAL_ERROR_INVALID_ARGUMENT;
     bal_x86_emit_ret(&assembler);
     EXPECT_EQ(assembler.offset, 0);
+
+    assembler.status = BAL_ERROR_INVALID_ARGUMENT;
+    bal_x86_emit_sub_r64_r64(&assembler, BAL_X86_RAX, BAL_X86_RBX);
+    EXPECT_EQ(assembler.offset, 0);
 }
 
 TEST_F(Backendx86Assembler, Public_InvalidRegister_NoEmit)
@@ -162,6 +167,14 @@ TEST_F(Backendx86Assembler, Public_InvalidRegister_NoEmit)
 
     assembler.status = BAL_SUCCESS;
     bal_x86_emit_add_r64_r64(&assembler, BAL_X86_RAX, bad_register);
+    EXPECT_EQ(assembler.status, BAL_ERROR_INVALID_ARGUMENT);
+
+    assembler.status = BAL_SUCCESS;
+    bal_x86_emit_sub_r64_r64(&assembler, bad_register, BAL_X86_RAX);
+    EXPECT_EQ(assembler.status, BAL_ERROR_INVALID_ARGUMENT);
+
+    assembler.status = BAL_SUCCESS;
+    bal_x86_emit_sub_r64_r64(&assembler, BAL_X86_RAX, bad_register);
     EXPECT_EQ(assembler.status, BAL_ERROR_INVALID_ARGUMENT);
 
     assembler.status = BAL_SUCCESS;
@@ -340,6 +353,26 @@ TEST_F(Backendx86Assembler, Encode_AddRegToReg_HighHigh)
     EXPECT_EQ(assembler.offset, 3);
     EXPECT_EQ(assembler.buffer[0], 0x4D); // REX.W | REX.R | REX.B
     EXPECT_EQ(assembler.buffer[1], 0x03); // Opcode
+    EXPECT_EQ(assembler.buffer[2], 0xFE); // ModRM
+}
+
+TEST_F(Backendx86Assembler, Encode_SubRegToReg_LowLow)
+{
+    bal_x86_emit_sub_r64_r64(&assembler, BAL_X86_RAX, BAL_X86_RBX);
+    EXPECT_EQ(assembler.status, BAL_SUCCESS);
+    EXPECT_EQ(assembler.offset, 3);
+    EXPECT_EQ(assembler.buffer[0], 0x48); // REX.W
+    EXPECT_EQ(assembler.buffer[1], 0x2B); // Opcode
+    EXPECT_EQ(assembler.buffer[2], 0xC3); // ModRM
+}
+
+TEST_F(Backendx86Assembler, Encode_SubRegToReg_HighHigh)
+{
+    bal_x86_emit_sub_r64_r64(&assembler, BAL_X86_R15, BAL_X86_R14);
+    EXPECT_EQ(assembler.status, BAL_SUCCESS);
+    EXPECT_EQ(assembler.offset, 3);
+    EXPECT_EQ(assembler.buffer[0], 0x4D); // REX.W | REX.R | REX.B
+    EXPECT_EQ(assembler.buffer[1], 0x2B); // Opcode
     EXPECT_EQ(assembler.buffer[2], 0xFE); // ModRM
 }
 


### PR DESCRIPTION
assembler: add bal_x86_emit_sub_r64_r64 + tests

Emit function with the standard 5-check guard. Two byte-exact
encode tests and the three safety tests. That's it for this PR —
the compiler side follows.

- `bal_x86_emit_sub_r64_r64`: 5-check guard, REX.W + ModRM, 3 bytes
- `Encode_SubRegToReg_LowLow`: sub RAX, RBX → 48 2B C3
- `Encode_SubRegToReg_HighHigh`: sub R15, R14 → 4D 2B FE
- Added to NullContext, BadStatus, and InvalidRegister safety tests

Signed-off-by: mcrib884 <farukkaya229@outlook.com>