### PR TITLE
[47] fix typo in compiler cache name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           path: ~/.ccache
           key: ${{ runner.os }}-clang-18-${{ matrix.type }}-ccache-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-clang-18-${{ matrix.type }}-cache-
+            ${{ runner.os }}-clang-18-${{ matrix.type }}-ccache-
 
       - name: Prepare ccache
         run: |


### PR DESCRIPTION
## Description

This PR is only used for testing the CI to solve #44 and will be closed when solved.
