### PR TITLE
[38] docs: load the libclang C API and find builtin headers

### DIFF
--- a/tools/scripts/include/cdoc/clang.lua
+++ b/tools/scripts/include/cdoc/clang.lua
@@ -1,22 +1,24 @@
 local script_path = debug.getinfo(1, "S").source:sub(2)
 local script_dir = script_path:match("(.*[/\\])") or "./"
-package.path = package.path .. ";" .. script_dir .. "/?.lua"
+local parent_dir = script_dir:gsub("[^/\\]+[/\\]$", "")
+package.path = package.path .. ";" .. script_dir .. "?.lua;" .. parent_dir .. "?.lua"
 
 local log = require('log')
 local ffi = require('ffi')
 
+-- CXSourceLocation layout must match Index.h.
 ffi.cdef[[
 typedef void* CXIndex;
 typedef void* CXTranslationUnit;
 typedef void* CXClientData;
 
-typedef struct { void *data; unsigned private_flags; } CXSourceLocation;
+typedef struct { void *ptr_data[2]; unsigned int_data; } CXSourceLocation;
 typedef struct { int kind; int xdata; void *data[3]; } CXCursor;
 typedef struct { int kind; void *data[2]; } CXType;
 typedef struct { const char *data; unsigned private_flags; } CXString;
-
-typedef enum { CXChildVisit_Break = 0, CXChildVisit_Continue = 1, CXChildVisit_Recurse = 2 } CXChildVisitResult;
-typedef CXChildVisitResult (*CXCursorVisitor)(CXCursor cursor, CXCursor parent, CXClientData client_data);
+typedef void *CXFile;
+typedef struct { void *ptr_data[2]; unsigned begin_int_data; unsigned end_int_data; } CXSourceRange;
+typedef struct { unsigned int_data[4]; void *ptr_data; } CXToken;
 
 CXIndex clang_createIndex(int excludeDeclarationsFromPCH, int displayDiagnostics);
 void clang_disposeIndex(CXIndex index);
@@ -38,16 +40,38 @@ int clang_Location_isFromMainFile(CXSourceLocation);
 long long clang_getEnumConstantDeclValue(CXCursor);
 CXType clang_getTypedefDeclUnderlyingType(CXCursor);
 CXCursor clang_getTypeDeclaration(CXType);
-unsigned clang_visitChildren(CXCursor parent, CXCursorVisitor visitor, CXClientData client_data);
+
+CXSourceRange clang_getCursorExtent(CXCursor);
+CXFile clang_getFile(CXTranslationUnit, const char *file_name);
+CXSourceLocation clang_getLocationForOffset(CXTranslationUnit, CXFile, unsigned offset);
+CXSourceRange clang_getRange(CXSourceLocation begin, CXSourceLocation end);
+CXSourceLocation clang_getRangeStart(CXSourceRange range);
+CXSourceLocation clang_getRangeEnd(CXSourceRange range);
+const char *clang_getFileContents(CXTranslationUnit, CXFile, size_t *size);
+void clang_tokenize(CXTranslationUnit TU, CXSourceRange Range, CXToken **Tokens, unsigned *NumTokens);
+void clang_annotateTokens(CXTranslationUnit TU, CXToken *Tokens, unsigned NumTokens, CXCursor *Cursors);
+void clang_disposeTokens(CXTranslationUnit TU, CXToken *Tokens, unsigned NumTokens);
+void clang_getExpansionLocation(CXSourceLocation location, CXFile *file, unsigned *line, unsigned *column, unsigned *offset);
+int clang_equalCursors(CXCursor, CXCursor);
+CXCursor clang_getCursorSemanticParent(CXCursor);
+int clang_getFieldDeclBitWidth(CXCursor);
 
 CXString clang_getTypeSpelling(CXType);
 CXType clang_getCanonicalType(CXType);
 CXType clang_getPointeeType(CXType);
 CXType clang_getResultType(CXType);
 int clang_getNumArgTypes(CXType);
+CXType clang_getArgType(CXType T, unsigned i);
 
 const char *clang_getCString(CXString string);
 void clang_disposeString(CXString string);
+CXString clang_getClangVersion(void);
+
+typedef void *CXDiagnostic;
+unsigned clang_getNumDiagnostics(CXTranslationUnit Unit);
+CXDiagnostic clang_getDiagnostic(CXTranslationUnit Unit, unsigned Index);
+unsigned clang_getDiagnosticSeverity(CXDiagnostic);
+void clang_disposeDiagnostic(CXDiagnostic);
 
 typedef struct DIR DIR;
 struct dirent {
@@ -123,7 +147,30 @@ local function check_magic(context)
     return false
 end
 
-local function scan_directory_for_libraries(directory, prefix, suffix)
+-- Skip libclang-cpp; that ABI has no clang_createIndex.
+local function libclang_c_api_version(name)
+    if name:find("cpp", 1, true) then
+        return nil
+    end
+
+    local dashed = name:match("^libclang%-(%d+)%.so")
+    if dashed then
+        return tonumber(dashed)
+    end
+
+    local so_ver = name:match("^libclang%.so%.(%d+)")
+    if so_ver then
+        return tonumber(so_ver)
+    end
+
+    if name == "libclang.so" or name == "libclang.dylib" or name == "libclang.dll" then
+        return 0
+    end
+
+    return nil
+end
+
+local function scan_directory_for_libraries(directory)
     local results = {}
     local d = ffi.C.opendir(directory)
 
@@ -143,47 +190,47 @@ local function scan_directory_for_libraries(directory, prefix, suffix)
 
         scanned = scanned + 1
         local name = ffi.string(ent.d_name)
-        local matches = name:sub(1, #prefix) == prefix
+        local version_number = libclang_c_api_version(name)
 
-        if #suffix > 0 then
-            matches = matches and name:sub(-#suffix) == suffix
-        end
-
-        if matches then
-            local remainder = name:sub(#prefix + 1)
-            if #suffix > 0 then
-                remainder = remainder:sub(1, -#suffix - 1)
-            end
-
-            local version_string = remainder:match("^%.?([%d%.]+)")
-            local version_number = tonumber((version_string or "0"):match("^(%d+)")) or 0
+        if version_number then
             results[#results + 1] = { path = directory .. "/" .. name, version = version_number }
         end
     end
 
     ffi.C.closedir(d)
     log.debug("Scanned %d entries in '%s', found %d matching candidates.", scanned, directory, #results)
-    table.sort(results, function(a,b) return a.version > b.version
-    end)
+    return results
+end
 
-    local paths = {}
+local function append_windows_llvm_dlls(paths)
+    table.insert(paths, "C:\\Program Files\\LLVM\\bin\\libclang.dll")
+    table.insert(paths, "C:\\Program Files (x86)\\LLVM\\bin\\libclang.dll")
 
-    for _, r in ipairs(results) do
-        table.insert(paths, r.path)
+    local visual_studio_years = { "2022", "2019", "2017" }
+    local visual_studio_editions = { "Community", "Professional", "Enterprise", "BuildTools" }
+    local visual_studio_roots = {
+        "C:\\Program Files\\Microsoft Visual Studio",
+        "C:\\Program Files (x86)\\Microsoft Visual Studio",
+    }
+
+    for _, root in ipairs(visual_studio_roots) do
+        for _, year in ipairs(visual_studio_years) do
+            for _, edition in ipairs(visual_studio_editions) do
+                local llvm = root .. "\\" .. year .. "\\" .. edition .. "\\VC\\Tools\\Llvm"
+                table.insert(paths, llvm .. "\\bin\\libclang.dll")
+                table.insert(paths, llvm .. "\\x86\\bin\\libclang.dll")
+                table.insert(paths, llvm .. "\\x64\\bin\\libclang.dll")
+            end
+        end
     end
-
-    return paths
 end
 
 local function get_common_paths()
     local os_name = jit and jit.os or "Unknown"
     log.info("Detecting libclang paths for %s.", os_name)
 
-    local paths = {
-        "clang", "libclang", "libclang.so", "libclang.dylib", "libclang.dll",
-        "libclang-20", "libclang-19", "libclang-18", "libclang-17", "libclang-16",
-        "libclang-15", "libclang-14", "libclang-13"
-    }
+    -- ffi.load("libclang") on Windows loads a DLL from CWD.
+    local paths = {}
 
     if os_name == "Linux" then
         local directories = {
@@ -192,48 +239,74 @@ local function get_common_paths()
         }
 
         for i = 10, 22 do
+            table.insert(directories, string.format("/usr/lib/llvm-%d/lib", i))
+            table.insert(directories, string.format("/usr/lib/llvm-%d/lib64", i))
             table.insert(directories, string.format("/usr/lib/llvm%d/lib/", i))
             table.insert(directories, string.format("/usr/lib/llvm%d/lib64/", i))
         end
 
         log.debug("Searching %d directories.", #directories)
 
+        local candidates = {}
         for _, directory in ipairs(directories) do
-            local found = scan_directory_for_libraries(directory, "libclang.so", "")
-
-            for _, path in ipairs(found) do
-                table.insert(paths, path)
+            local found = scan_directory_for_libraries(directory)
+            for _, item in ipairs(found) do
+                candidates[#candidates + 1] = item
             end
         end
+        table.sort(candidates, function(a, b)
+            return a.version > b.version
+        end)
+        for _, item in ipairs(candidates) do
+            table.insert(paths, item.path)
+        end
     elseif os_name == "Windows" then
-        table.insert(paths, "C:\\Program Files\\LLVM\\bin\\libclang.dll")
-        table.insert(paths, "C:\\Program Files (x86)\\LLVM\\bin\\libclang.dll")
-
-        local visual_studio_years = { "2022", "2019", "2017" }
-        local visual_studio_editions = { "Community", "Professional", "Enterprise", "BuildTools" }
-        local visual_studio_roots = {
-            "C:\\Program Files\\Microsoft Visual Studio",
-            "C:\\Program Files (x86)\\Microsoft Visual Studio",
-        }
-
-        for _, root in ipairs(visual_studio_roots) do
-            for _, year in ipairs(visual_studio_years) do
-                for _, edition in ipairs(visual_studio_editions) do
-                    local base = root .. "\\" .. year .. "\\" .. edition .. "\\VC\\Tools\\Llvm" .. "\\x86"
-                    table.insert(paths, base .. "\\bin\\libclang.dll")
-                end
-            end
+        append_windows_llvm_dlls(paths)
+    elseif os_name == "OSX" then
+        table.insert(paths, "/opt/homebrew/opt/llvm/lib/libclang.dylib")
+        table.insert(paths, "/usr/local/opt/llvm/lib/libclang.dylib")
+        table.insert(
+            paths,
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
+        )
+        table.insert(paths, "/Library/Developer/CommandLineTools/usr/lib/libclang.dylib")
+        for i = 22, 10, -1 do
+            table.insert(paths, string.format("/opt/homebrew/opt/llvm@%d/lib/libclang.dylib", i))
+            table.insert(paths, string.format("/usr/local/opt/llvm@%d/lib/libclang.dylib", i))
         end
     else
         log.warn("Unrecognized OS '%s', using base library names only.", os_name)
     end
 
+    if os_name ~= "Windows" then
+        table.insert(paths, "libclang.so")
+        table.insert(paths, "libclang.dylib")
+        table.insert(paths, "libclang.dll")
+        table.insert(paths, "libclang")
+    end
+
     return paths
+end
+
+local function library_exports_c_api(library)
+    -- LuaJIT looks up the C symbol before pcall.
+    local ok, index = pcall(function()
+        return library.clang_createIndex(0, 0)
+    end)
+    if not ok then
+        return false, tostring(index)
+    end
+    if index == nil then
+        return false, "clang_createIndex returned NULL"
+    end
+    library.clang_disposeIndex(index)
+    return true
 end
 
 function M.create_context()
     return {
         library = nil,
+        library_path = nil,
         status = M.ERROR.INVALID_ARGUMENT,
         magic = M.MAGIC_UNINITIALIZED,
     }
@@ -259,11 +332,19 @@ function M.init(context, custom_path)
         log.trace("Attempt %d/%d: ffi.load('%s')", attempt, #paths, path)
         local ok, library = pcall(ffi.load, path)
         if ok then
-            log.info("Successfully loaded libclang from %s (attempt %d/%d).", path, attempt, #paths)
-            context.library = library
-            context.status = M.ERROR.SUCCESS
-            context.magic = M.MAGIC_ALIVE
-            return true
+            local has_c_api, api_error = library_exports_c_api(library)
+            if has_c_api then
+                log.info("Successfully loaded libclang from %s (attempt %d/%d).", path, attempt, #paths)
+                context.library = library
+                context.library_path = path
+                context.status = M.ERROR.SUCCESS
+                context.magic = M.MAGIC_ALIVE
+                return true
+            end
+            local error_message = "loaded '" .. path .. "' but it is not the libclang C API: " .. tostring(api_error)
+            table.insert(errors, error_message)
+            log.trace("Failed: %s", error_message)
+            attempt = attempt + 1
         else
             local error_message = tostring(library)
             table.insert(errors, error_message)
@@ -294,10 +375,11 @@ function M.destroy(context)
         return
     end
 
-    if not check_magic(context) then
+    if check_magic(context) then
         log.info("Destroying clang context.")
         context.library = nil
-        context.status = M.ERROR.STRUCT_CORRUPTED
+        context.library_path = nil
+        context.status = M.ERROR.SUCCESS
         context.magic = M.MAGIC_DEAD
     end
 end
@@ -345,6 +427,5 @@ function M.resource_directory(context)
     log.warn("Could not locate clang resource directory.")
     return nil
 end
-
 
 return M

--- a/tools/scripts/include/cdoc/clang.lua
+++ b/tools/scripts/include/cdoc/clang.lua
@@ -384,10 +384,169 @@ function M.destroy(context)
     end
 end
 
+local function dirname(path)
+    if type(path) ~= "string" then
+        return nil
+    end
+    return path:match("^(.*)[/\\][^/\\]+$")
+end
+
+local function has_stdarg(include_dir)
+    local probe = io.open(include_dir .. "/stdarg.h", "r") or io.open(include_dir .. "\\stdarg.h", "r")
+    if probe then
+        probe:close()
+        return true
+    end
+    return false
+end
+
+local function list_dir_names(directory)
+    local names = {}
+    if jit.os ~= "Linux" then
+        return names
+    end
+    local opened, d = pcall(function()
+        return ffi.C.opendir(directory)
+    end)
+    if not opened or d == nil then
+        return names
+    end
+    while true do
+        local ent = ffi.C.readdir(d)
+        if ent == nil then
+            break
+        end
+        local name = ffi.string(ent.d_name)
+        if name ~= "." and name ~= ".." then
+            names[#names + 1] = name
+        end
+    end
+    ffi.C.closedir(d)
+    return names
+end
+
+local function clang_version_dir_names(library)
+    local names = {}
+    if library == nil then
+        return names, nil
+    end
+    local ok, version = pcall(function()
+        local cx = library.clang_getClangVersion()
+        local ptr = library.clang_getCString(cx)
+        local text = (ptr ~= nil) and ffi.string(ptr) or ""
+        library.clang_disposeString(cx)
+        return text
+    end)
+    if not ok or type(version) ~= "string" then
+        return names, nil
+    end
+    local fullVersion = version:match("(%d+%.%d+%.%d+)")
+    local major = version:match("(%d+)")
+    if fullVersion then
+        names[#names + 1] = fullVersion
+    end
+    if major and major ~= fullVersion then
+        names[#names + 1] = major
+    end
+    return names, fullVersion
+end
+
+local function wanted_resource_major(extra_names)
+    if not extra_names or extra_names[1] == nil then
+        return nil
+    end
+    return tonumber(extra_names[#extra_names]:match("^(%d+)"))
+end
+
+local function clang_include_under(clang_versions_dir, extra_names)
+    if extra_names then
+        for _, name in ipairs(extra_names) do
+            local include_dir = clang_versions_dir .. "/" .. name .. "/include"
+            if has_stdarg(include_dir) then
+                return include_dir
+            end
+        end
+    end
+    local names
+    if jit.os == "Linux" then
+        names = list_dir_names(clang_versions_dir)
+    else
+        -- io.open so Windows does not need opendir.
+        names = {}
+        for ver = 22, 10, -1 do
+            names[#names + 1] = tostring(ver)
+        end
+    end
+    -- use the resource dir that matches the loaded libclang version.
+    local need = wanted_resource_major(extra_names)
+    local best_ver = -1
+    local best_path = nil
+    for _, name in ipairs(names) do
+        local include_dir = clang_versions_dir .. "/" .. name .. "/include"
+        if has_stdarg(include_dir) then
+            local major = tonumber(name:match("^(%d+)")) or 0
+            if (not need or major == need) and major > best_ver then
+                best_ver = major
+                best_path = include_dir
+            end
+        end
+    end
+    return best_path
+end
+
+local function resource_dir_from_library_path(library_path, extra_names, fullVersion)
+    if type(library_path) ~= "string" or not library_path:find("[/\\]") then
+        return nil
+    end
+
+    local dir = dirname(library_path)
+    local seen = {}
+    local clang_roots = {}
+    local function add_root(path)
+        if path and not seen[path] then
+            seen[path] = true
+            clang_roots[#clang_roots + 1] = path
+        end
+    end
+
+    local walk = dir
+    for _ = 1, 4 do
+        if not walk then
+            break
+        end
+        add_root(walk .. "/clang")
+        add_root(walk .. "/lib/clang")
+        add_root(walk .. "/lib64/clang")
+        walk = dirname(walk)
+    end
+
+    for _, clang_root in ipairs(clang_roots) do
+        local found = clang_include_under(clang_root, extra_names)
+        if found then
+            return found
+        end
+        if fullVersion and has_stdarg(clang_root .. "/" .. fullVersion .. "/include") then
+            return clang_root .. "/" .. fullVersion .. "/include"
+        end
+        if has_stdarg(clang_root .. "/include") then
+            return clang_root .. "/include"
+        end
+    end
+
+    return nil
+end
+
 function M.resource_directory(context)
     if context == nil then
         log.error("Aborting function: context is NULL.")
         return nil
+    end
+
+    local version_names, fullVersion = clang_version_dir_names(context.library)
+    local from_library = resource_dir_from_library_path(context.library_path, version_names, fullVersion)
+    if from_library then
+        log.info("Found clang resource dir: %s", from_library)
+        return from_library
     end
 
     local os_name = jit and jit.os or "Unknown"
@@ -400,32 +559,71 @@ function M.resource_directory(context)
             candidates[#candidates + 1] = string.format("/usr/lib/llvm-%d/lib/clang/%d/include", ver, ver)
             candidates[#candidates + 1] = string.format("/usr/local/lib/clang/%d/include", ver)
         end
-    end
-
-    for _, path in ipairs(candidates) do
-        local d = ffi.C.opendir(path)
-
-        if d ~= nil then
-            while true do
-                local ent = ffi.C.readdir(d)
-
-                if ent == nil then
+        local found = clang_include_under("/usr/lib/clang", version_names)
+            or clang_include_under("/usr/lib64/clang", version_names)
+            or clang_include_under("/usr/local/lib/clang", version_names)
+        if found then
+            log.info("Found clang resource dir: %s", found)
+            return found
+        end
+    elseif os_name == "OSX" then
+        local found = clang_include_under("/opt/homebrew/opt/llvm/lib/clang", version_names)
+            or clang_include_under("/usr/local/opt/llvm/lib/clang", version_names)
+            or clang_include_under("/Library/Developer/CommandLineTools/usr/lib/clang", version_names)
+        if not found then
+            for ver = 22, 10, -1 do
+                found = clang_include_under(string.format("/opt/homebrew/opt/llvm@%d/lib/clang", ver), version_names)
+                    or clang_include_under(string.format("/usr/local/opt/llvm@%d/lib/clang", ver), version_names)
+                if found then
                     break
                 end
-
-                if ffi.string(ent.d_name) == "stdarg.h" then
-                    ffi.C.closedir(d)
-                    log.info("Found clang resource dir: %s", path)
-                    return path
-                end
             end
+        end
+        if found then
+            log.info("Found clang resource dir: %s", found)
+            return found
+        end
+        for _, name in ipairs(version_names) do
+            candidates[#candidates + 1] = string.format("/opt/homebrew/opt/llvm/lib/clang/%s/include", name)
+            candidates[#candidates + 1] = string.format("/usr/local/opt/llvm/lib/clang/%s/include", name)
+            candidates[#candidates + 1] = string.format("/Library/Developer/CommandLineTools/usr/lib/clang/%s/include", name)
+        end
+        for ver = 22, 10, -1 do
+            candidates[#candidates + 1] = string.format("/opt/homebrew/opt/llvm/lib/clang/%d/include", ver)
+            candidates[#candidates + 1] = string.format("/usr/local/opt/llvm/lib/clang/%d/include", ver)
+            candidates[#candidates + 1] = string.format("/opt/homebrew/opt/llvm@%d/lib/clang/%d/include", ver, ver)
+            candidates[#candidates + 1] = string.format("/usr/local/opt/llvm@%d/lib/clang/%d/include", ver, ver)
+            candidates[#candidates + 1] = string.format("/Library/Developer/CommandLineTools/usr/lib/clang/%d/include", ver)
+        end
+    elseif os_name == "Windows" then
+        local found = clang_include_under("C:\\Program Files\\LLVM\\lib\\clang", version_names)
+            or clang_include_under("C:\\Program Files (x86)\\LLVM\\lib\\clang", version_names)
+        if found then
+            log.info("Found clang resource dir: %s", found)
+            return found
+        end
+        for _, name in ipairs(version_names) do
+            candidates[#candidates + 1] = string.format("C:\\Program Files\\LLVM\\lib\\clang\\%s\\include", name)
+            candidates[#candidates + 1] = string.format("C:\\Program Files (x86)\\LLVM\\lib\\clang\\%s\\include", name)
+        end
+        for ver = 22, 10, -1 do
+            candidates[#candidates + 1] = string.format("C:\\Program Files\\LLVM\\lib\\clang\\%d\\include", ver)
+            candidates[#candidates + 1] = string.format("C:\\Program Files (x86)\\LLVM\\lib\\clang\\%d\\include", ver)
+        end
+    end
 
-            ffi.C.closedir(d)
+    local need = wanted_resource_major(version_names)
+    for _, path in ipairs(candidates) do
+        if has_stdarg(path) then
+            local major = tonumber(path:match("[/\\]clang[/\\](%d+)"))
+            if not need or major == need then
+                log.info("Found clang resource dir: %s", path)
+                return path
+            end
         end
     end
 
     log.warn("Could not locate clang resource directory.")
     return nil
 end
-
 return M


### PR DESCRIPTION
## Description
ffi.load can bind libclang-cpp, which has no clang_createIndex. CXSourceLocation does not match Index.h, and destroy left a live context MAGIC_ALIVE.

clang still needs its stdarg.h. MSVCRT has no opendir, so resource directories are found with io.open.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)